### PR TITLE
job location

### DIFF
--- a/seamm_datastore/database/build.py
+++ b/seamm_datastore/database/build.py
@@ -151,9 +151,9 @@ def import_datastore(session, location, as_json=True):
                             job = api.add_job(
                                 session,
                                 job_data["id"],
-                                job_data["path"] + "/flowchart.flow",
+                                potential_job + "/flowchart.flow",
                                 project_names=job_data["project_names"],
-                                path=job_data["path"],
+                                path=potential_job,
                                 title=job_data["title"],
                                 description=job_data.get("description", ""),
                                 submitted=job_data.get("submitted", None),


### PR DESCRIPTION
## Description
This PR changes the behavior of adding a job when the `import_datastore` function is used. Before this PR, the location is assumed to be the directory which is present in `job_data.json` rather than the location of `job_data.json`. This PR changes behavior so that the current location of the job is used.