### PR TITLE
add last updated column to jobs table

### DIFF
--- a/seamm_datastore/database/models.py
+++ b/seamm_datastore/database/models.py
@@ -169,7 +169,9 @@ class Job(Base, AccessControlPermissionsMixin):
     started = Column(DateTime, nullable=True)
     finished = Column(DateTime, nullable=True)
     status = Column(String, nullable=False, default="imported")
-    last_update = Column(DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+    last_update = Column(
+        DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
 
     flowchart = relationship("Flowchart", back_populates="jobs")
     projects = relationship("Project", secondary=job_project, back_populates="jobs")

--- a/seamm_datastore/database/models.py
+++ b/seamm_datastore/database/models.py
@@ -169,6 +169,7 @@ class Job(Base, AccessControlPermissionsMixin):
     started = Column(DateTime, nullable=True)
     finished = Column(DateTime, nullable=True)
     status = Column(String, nullable=False, default="imported")
+    last_update = Column(DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
 
     flowchart = relationship("Flowchart", back_populates="jobs")
     projects = relationship("Project", secondary=job_project, back_populates="jobs")


### PR DESCRIPTION
This adds a column called `last_updated` to the jobs table. This entry will be updated automatically to `datetime.utcnow` any time a job is changed.