### PR TITLE
Adding parameters to the jobs.

### DIFF
--- a/seamm_datastore/api.py
+++ b/seamm_datastore/api.py
@@ -92,6 +92,7 @@ def add_job(
     path=None,
     title="",
     description="",
+    parameters={},
     submitted=datetime.datetime.now(datetime.timezone.utc),
     started=None,
     finished=None,
@@ -120,6 +121,8 @@ def add_job(
         The title of the job, used for display.
     description : str = ""
         A longer, textual description of the job.
+    parameters : dict = {}
+        The command-line parameters for the job.
     submitted : datetime.datetime = now()
         When the job was submitted as a datetime object. Defaults to now in UTC.
     started : datetime.datetime = None
@@ -189,6 +192,7 @@ def add_job(
         path=path,
         flowchart=flowchart,
         projects=projects,
+        parameters=parameters,
         status=status,
         submitted=submitted,
         started=started,

--- a/seamm_datastore/database/models.py
+++ b/seamm_datastore/database/models.py
@@ -172,6 +172,7 @@ class Job(Base, AccessControlPermissionsMixin):
     last_update = Column(
         DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow
     )
+    parameters = Column(JSON, nullable=True)
 
     flowchart = relationship("Flowchart", back_populates="jobs")
     projects = relationship("Project", secondary=job_project, back_populates="jobs")


### PR DESCRIPTION
## Description
Allow the specification of command-line parameters to a flowchart when submitting via the GUI.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add a JSON column to the Jobs table.
  - [x] Update the API for add_job to handle the parameters.

## Questions
- [ ] Any idea how to make updates to the schema on-the-fly, i.e. automatically update the schema with a default value, for compatibility with existing databases?Not critical now, but eventually we will have to learn how to do this! This might be a time to learn...

## Status
- [x] Ready to go if we remake databases.