### PR TITLE
allow repeated project names when building the datastore

### DIFF
--- a/seamm_datastore/database/build.py
+++ b/seamm_datastore/database/build.py
@@ -108,19 +108,21 @@ def import_datastore(session, location, as_json=True):
                 "path": potential_project,
             }
 
-            if project_name != "default":
+            try:
                 project = Project.create(
                     name=project_name,
                     path=potential_project,
                     group=group,
                 )
                 session.add(project)
-
-            try:
                 session.commit()
-            except Exception as e:
+            except ValueError:
+                # Project already in DB
+                print(
+                    f"Project {project_name} not imported because it is "
+                    "already in the database."
+                )
                 session.rollback()
-                raise e
 
             project_names.append(project_data["name"])
 

--- a/seamm_datastore/database/models.py
+++ b/seamm_datastore/database/models.py
@@ -787,5 +787,5 @@ class Project(Base, Resource):
         update_dict = {x: local[x] for x in possible_updates if local[x] is not None}
         project = Project.query.get(id)
 
-        Project.query.filter(Project.id==id).update(update_dict)
+        Project.query.filter(Project.id == id).update(update_dict)
         return project

--- a/seamm_datastore/database/models.py
+++ b/seamm_datastore/database/models.py
@@ -667,13 +667,14 @@ class Job(Base, Resource):
         local = locals()
         update_dict = {x: local[x] for x in possible_updates if local[x] is not None}
 
-        job = cls.query.get(id)
-
         for k, v in update_dict.items():
             if k == "submitted" or k == "finished" or k == "started":
-                update_dict[k] = datetime.fromtimestamp(v / 1000)
+                if v:
+                    update_dict[k] = datetime.fromtimestamp(v / 1000)
+                else:
+                    update_dict[k] = None
 
-        job.query.update(update_dict)
+        Job.query.filter(Job.id == id).update(update_dict)
 
         return job
 
@@ -786,5 +787,5 @@ class Project(Base, Resource):
         update_dict = {x: local[x] for x in possible_updates if local[x] is not None}
         project = Project.query.get(id)
 
-        project.query.update(update_dict)
+        Project.query.filter(Project.id==id).update(update_dict)
         return project


### PR DESCRIPTION
This PR allows repeated project names when building the datastore and fixes a bug in the job and project update functions.