### PR TITLE
fix bug in session commit

### DIFF
--- a/seamm_datastore/database/build.py
+++ b/seamm_datastore/database/build.py
@@ -156,6 +156,7 @@ def import_datastore(session, location, as_json=True):
                             )
                         else:
                             session.add(job)
+                            session.commit()
                             jobs.append(job)
 
     session.commit()

--- a/seamm_datastore/tests/test_build.py
+++ b/seamm_datastore/tests/test_build.py
@@ -7,10 +7,15 @@ import os
 
 def test_build(connection):
 
+    from seamm_datastore.database.models import Flowchart
+
     loc = os.path.abspath(os.path.dirname(__file__))
     added_jobs, added_projects = connection.import_datastore(
         os.path.join(loc, "..", "data", "Projects")
     )
 
+    flowcharts = Flowchart.permissions_query(permission="read").all()
+
     assert len(added_jobs) == 2
     assert len(added_projects) == 1, added_projects
+    assert len(flowcharts) == 1

--- a/seamm_datastore/tests/test_methods.py
+++ b/seamm_datastore/tests/test_methods.py
@@ -60,7 +60,7 @@ import pytest
             None,
             "id",
             "asc",
-            2,
+            1,
             1,
         ),  # Test retrieving all flowcharts
         ("job", None, None, 1, None, "id", "asc", 1, 93),  # Get jobs with offset


### PR DESCRIPTION
session commit should occur after each job is added to avoid adding the same flowchart (identical sha256_strict) more than once

