### PR TITLE
Update create function for User

### DIFF
--- a/seamm_datastore/connect.py
+++ b/seamm_datastore/connect.py
@@ -152,9 +152,6 @@ class SEAMMDatastore:
         # Current user has to be bound before we can add anything else to be database.
         self.authorize = Authorize(current_user=self.current_user)
 
-        # Default group
-        self.default_group = Group.query.get(2).name
-
         # Now handle the project
         project = Project.query.filter_by(name=default_project).one_or_none()
         if not project:

--- a/seamm_datastore/database/models.py
+++ b/seamm_datastore/database/models.py
@@ -166,12 +166,20 @@ class User(Base):
             role = Role.query.filter_by(name=role_name).one()
             new_user.roles.append(role)
 
-        if groups is None:
-            groups = [Group.query.get(2).name]
+        if not groups:
+            new_group = Group.create(username, [])
+            new_user.groups.append(new_group)
+        else:
+            for group_name in groups:
+                group = Group.query.filter_by(name=group_name).one()
+                new_user.groups.append(group)
 
-        for group_name in groups:
-            group = Group.query.filter_by(name=group_name).one()
-            new_user.groups.append(group)
+        if not roles:
+            new_user.roles.append(Role.query.filter_by(name="user").one())
+        else:
+            for role in roles:
+                role = Role.query.filter_by(name=role).one()
+                new_user.roles.append(role)
 
         return new_user
 

--- a/seamm_datastore/tests/test_create.py
+++ b/seamm_datastore/tests/test_create.py
@@ -71,7 +71,7 @@ def test_create_user(connection):
     user = connection.User.create(username="test", password="test")
 
     assert user.username == "test"
-    assert user.groups[0].name == connection.default_group
+    assert user.groups[0].name == user.username
 
 
 def test_add_job(connection):


### PR DESCRIPTION
## Description
This updates the `create` function for users to improve logic for adding groups and roles.

Previously, no default was added if an empty list was input for groups (was checking only for `None`). This has been updated so that a default group is added if what is passed in for groups evaluates as `False`.

The default group is also changed to be the same as the username if not specified, rather than the second group in the database.